### PR TITLE
change gitsubmodule url to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libs/etl_modm"]
 	path = libs/etl_modm
-	url = git@github.com:DroidDrive/etl_modm
+	url = https://github.com/DroidDrive/etl_modm
 	branch = master
 [submodule "libs/lely_modm"]
 	path = libs/lely_modm


### PR DESCRIPTION
The current settings lead to clone errors for people who do not belong to the org, hence the fix.

Note: there are more recursive submodules that have the same problem.